### PR TITLE
Fix bsd::mac_of()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,9 +466,12 @@ mod bsd {
         // See: https://illumos.org/man/3socket/sockaddr_dl
         let start = addr.sdl_nlen as usize; // length of the if name.
         let end = start + addr.sdl_alen as usize;
+        let data = unsafe {
+            std::slice::from_raw_parts(&addr.sdl_data as *const _ as *const u8, end)
+        };
 
-        if let [b0, b1, b2, b3, b4, b5] = addr.sdl_data[start..end] {
-            Some([b0 as u8, b1 as u8, b2 as u8, b3 as u8, b4 as u8, b5 as u8])
+        if let [b0, b1, b2, b3, b4, b5] = data[start..end] {
+            Some([b0, b1, b2, b3, b4, b5])
         } else {
             None
         }


### PR DESCRIPTION
`sockaddr_dl.sdl_data` must be treated as variable length.

e.g. on macOS, the definition of `sockaddr_dl` is:

```c
struct sockaddr_dl {
        u_char  sdl_len;        /* Total length of sockaddr */
        u_char  sdl_family;     /* AF_LINK */
        u_short sdl_index;      /* if != 0, system given index for interface */
        u_char  sdl_type;       /* interface type */
        u_char  sdl_nlen;       /* interface name length, no trailing 0 reqd. */
        u_char  sdl_alen;       /* link level address length */
        u_char  sdl_slen;       /* link layer selector length */
        char    sdl_data[12];   /* minimum work area, can be larger;
                                 *  contains both if name and ll address */
#ifndef __APPLE__
        /* For TokenRing */
        u_short sdl_rcf;        /* source routing control */
        u_short sdl_route[16];  /* source routing information */
#endif
};
```

Therefore, when interface name is longer than 6, `end` is larger than 12 and then `sdl_data[start..end]` is out of range.